### PR TITLE
FISH-449 Temporarily map Oracle DB 18 & 19 to 12

### DIFF
--- a/foundation/org.eclipse.persistence.core/resource/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
+++ b/foundation/org.eclipse.persistence.core/resource/org/eclipse/persistence/internal/helper/VendorNameToPlatformMapping.properties
@@ -28,8 +28,12 @@
 # to platform class entries should be placed before less specific entries. Each
 # platform entry must be on its own line, an entry cannot span multiple lines.
 
-(?is)oracle.*19.*=org.eclipse.persistence.platform.database.oracle.Oracle19Platform
-(?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle18Platform
+# FISH-449 Temporarily commented out due to inability to build the Oracle extensions. Added a temporary fix below 
+# which maps 18 & 19 to the 12 class, since the classes for 18 & 19 simply extend from 12 without any changes.
+#(?is)oracle.*19.*=org.eclipse.persistence.platform.database.oracle.Oracle19Platform
+#(?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle18Platform
+(?is)oracle.*19.*=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
+(?is)oracle.*18.*=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
 (?is)oracle.*12.*=org.eclipse.persistence.platform.database.oracle.Oracle12Platform
 (?is)oracle.*11.*=org.eclipse.persistence.platform.database.oracle.Oracle11Platform
 (?is)oracle.*10.*=org.eclipse.persistence.platform.database.oracle.Oracle10Platform


### PR DESCRIPTION
Maps Oracle DB [18 ](https://github.com/payara/patched-src-eclipselink/blob/eclipselink-2.6.8.payara-p2/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle18Platform.java)and [19 ](https://github.com/payara/patched-src-eclipselink/blob/eclipselink-2.6.8.payara-p2/foundation/org.eclipse.persistence.oracle/src/org/eclipse/persistence/platform/database/oracle/Oracle19Platform.java)to 12, since there aren't any actual functional changes in the connector between them and there are issues with the build of the oracle extensions.

This will unfoortunately have it detected as "12", but functionally there should be no difference.