### PR TITLE
FISH-8030 Fix NullPointerException in printCollection

### DIFF
--- a/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
+++ b/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/expressions/ExpressionOperator.java
@@ -2380,16 +2380,18 @@ public class ExpressionOperator implements Serializable {
             dbStringIndex = 1;
         }
 
-        if (this.argumentIndices == null) {
-            this.argumentIndices = new int[items.size()];
-            for (int i = 0; i < this.argumentIndices.length; i++){
-                this.argumentIndices[i] = i;
+        int[] indices = this.argumentIndices; // work on local copy, cannot be broken by concurrent requets
+        if (indices == null) {
+            indices = new int[items.size()];
+            for (int i = 0; i < indices.length; i++) {
+                indices[i] = i;
             }
+            this.argumentIndices = indices;
         }
 
         String[] dbStrings = getDatabaseStrings(items.size());
-        for (int i = 0; i < this.argumentIndices.length; i++) {
-            final int index = this.argumentIndices[i];
+        for (int i = 0; i < indices.length; i++) {
+            final int index = indices[i];
             Expression item = items.get(index);
             if ((this.selector == Ref) || ((this.selector == Deref) && (item.isObjectExpression()))) {
                 DatabaseTable alias = ((ObjectExpression)item).aliasForTable(((ObjectExpression)item).getDescriptor().getTables().firstElement());

--- a/payara-build.sh
+++ b/payara-build.sh
@@ -94,6 +94,10 @@ prepare() {
    tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/apache-maven-3.6.0-bin.tar.gz
 }
 
+upload() {
+   ant -f uploadToNexus.xml -Dmavenant.dir=target/ -Drelease.version=${VERSION} -Dbuild.type=RELEASE -Dgit.hash=`git rev-parse --short HEAD` -Dversion.string=${VERSION} -Dmaven.repo.dir=$HOME/.m2/repository -Dmaven.repo.url=https://nexus.dev.payara.fish/repository/payara-artifacts -DstagingId=payara-artifacts -DstagingURL=https://nexus.dev.payara.fish/repository/payara-artifacts -Dasm.version=${VERSION}
+}
+
 if [[ ! -d $M2_HOME ]] ; then
    usage
    echo ""
@@ -168,6 +172,10 @@ case "$CMD" in
 
    prepare)
       prepare
+      ;;
+
+   upload)
+      upload
       ;;
 
    *)

--- a/payara-build.sh
+++ b/payara-build.sh
@@ -9,6 +9,7 @@ Payara Eclipselink Build script
 Usage: $0 <command>
 
 Where command is:
+   prepare  Creates required direcory $HOME/extension.lib.external, downloads and unpacks required libs
    compile  Obviously  
    install  To install compilation result to your maven repo
    deploy   To deploy the compilation result into patched projects repo
@@ -24,7 +25,7 @@ Environment:
 "
 }
 compile() {
-   $ANT -f antbuild.xml -Dversion.qualifier=$QUALIFIER clean clean-runtime build-src
+   $ANT -f antbuild.xml -Dversion.qualifier=$QUALIFIER -Declipse.install.dir=$HOME/extension.lib.external/eclipse clean clean-runtime build-src
 }
 
 patch() {
@@ -52,13 +53,45 @@ install() {
      TARGET=$1
    fi
    rm pom.xml # That one is just temporary created during uploads
+   
+   # rename asm files, their name from compile are different than required by install
+   ASM_VERSION=`grep 'eclipselink.asm.version' buildsystem/compdeps/pom.xml | head -1 | awk 'match($0, /.*[>]([0-9.]+)[<].*/, v) {print v[1]}'`
+   echo "ASM_VERSION = ${ASM_VERSION}"
+   mv plugins/org.eclipse.persistence.asm-sources.jar plugins/org.eclipse.persistence.asm.source_${ASM_VERSION}.jar
+   mv plugins/org.eclipse.persistence.asm.jar plugins/org.eclipse.persistence.asm_${ASM_VERSION}.jar
+   
    $MVN dependency:copy -Dartifact=org.apache.maven:maven-ant-tasks:2.0.8:jar -DoutputDirectory=target/
-   $ANT -f uploadToMaven.xml -Dmavenant.dir=target/ -Drelease.version=$VERSION -Dbuild.type=RELEASE -Dgit.hash=`git rev-parse --short HEAD` -Dversion.string=$VERSION -Dmaven.repo.dir=$TARGET   
+   $ANT -f uploadToMaven.xml -Dmavenant.dir=target/ -Drelease.version=$VERSION -Dbuild.type=RELEASE -Dgit.hash=`git rev-parse --short HEAD` -Dversion.string=$VERSION -Dmaven.repo.dir=$TARGET -Dasm.version=${ASM_VERSION}  
 }
 
 deploy() {
    rm pom.xml
    $MVN wagon:merge-maven-repos -Dwagon.source=file://`realpath $STAGE` -Dwagon.target=file://`realpath $REPO`
+}
+
+prepare() {
+   echo "*************************************************************"
+   echo "**  Polluting your home with extension.lib.external!!!     **"
+   echo "*************************************************************"
+   mkdir -p $HOME/extension.lib.external/mavenant
+   mkdir -p $HOME/extension.lib.external/plugins
+
+   wget -nc https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar -O $HOME/extension.lib.external/junit-4.12.jar
+   wget -nc https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar -O $HOME/extension.lib.external/hamcrest-core-1.3.jar
+   wget -nc https://repo1.maven.org/maven2/org/jmockit/jmockit/1.35/jmockit-1.35.jar -O $HOME/extension.lib.external/jmockit-1.35.jar
+   wget -nc https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.3.0.Final/jboss-logging-3.3.0.Final.jar -O $HOME/extension.lib.external/jboss-logging-3.3.0.Final.jar
+   wget -nc https://repo1.maven.org/maven2/org/glassfish/javax.el/3.0.1-b08/javax.el-3.0.1-b08.jar -O $HOME/extension.lib.external/javax.el-3.0.1-b08.jar
+   wget -nc https://repo1.maven.org/maven2/com/fasterxml/classmate/1.3.1/classmate-1.3.1.jar -O $HOME/extension.lib.external/classmate-1.3.1.jar
+   wget -nc https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.48/mysql-connector-java-5.1.48.jar -O $HOME/extension.lib.external/mysql-connector-java-5.1.48.jar
+   wget -nc https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.7-bin.tar.gz -O $HOME/extension.lib.external/apache-ant-1.10.7-bin.tar.gz
+   wget -nc https://archive.apache.org/dist/maven/ant-tasks/2.1.3/binaries/maven-ant-tasks-2.1.3.jar -O $HOME/extension.lib.external/mavenant/maven-ant-tasks-2.1.3.jar
+   wget -nc https://download.jboss.org/wildfly/15.0.1.Final/wildfly-15.0.1.Final.tar.gz -O $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
+   wget -nc https://download.eclipse.org/eclipse/downloads/drops4/R-4.10-201812060815/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz -O $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+   wget -nc https://archive.apache.org/dist/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz -O $HOME/extension.lib.external/apache-maven-3.6.0-bin.tar.gz
+
+   tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/wildfly-15.0.1.Final.tar.gz
+   tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/eclipse-SDK-4.10-linux-gtk-x86_64.tar.gz
+   tar -x -z -C $HOME/extension.lib.external -f $HOME/extension.lib.external/apache-maven-3.6.0-bin.tar.gz
 }
 
 if [[ ! -d $M2_HOME ]] ; then
@@ -94,10 +127,12 @@ if [[ ! -d $REPO ]] ; then
 fi
 
 RELEASE_VERSION=`grep release.version autobuild.properties | cut -d= -f2`
-PATCH_VERSION=`grep $RELEASE_VERSION \
-   $REPO/org/eclipse/persistence/org.eclipse.persistence.core/maven-metadata.xml | \
-   tail -1 | \
-   awk 'match($0,/p([0-9])/,x) { print x[1]+1 }'`
+if [[ -z $PATCH_VERSION ]] ; then
+   PATCH_VERSION=`grep $RELEASE_VERSION \
+      $REPO/org/eclipse/persistence/org.eclipse.persistence.core/maven-metadata.xml | \
+      tail -1 | \
+      awk 'match($0,/p([0-9])/,x) { print x[1]+1 }'`
+fi
 
 if [[ -z $PATCH_VERSION ]] ; then
    PATCH_VERSION=0
@@ -130,6 +165,11 @@ case "$CMD" in
    patch)
       patch $2
       ;;
+
+   prepare)
+      prepare
+      ;;
+
    *)
       usage
       exit 1

--- a/uploadToNexus.xml
+++ b/uploadToNexus.xml
@@ -639,7 +639,7 @@
     <!-- Staging targets -->
     <target name="ua-staging" if="sign">
         <exec dir="${maven.build.location}" executable="sh">
-            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifact} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Poss-release'" />
+            <arg line="-c '${M2_HOME}/bin/mvn clean gpg:sign-and-deploy-file -Dfile=${artifact} -DpomFile=${maven.build.location}/pom.xml -Durl=${stagingURL} -DrepositoryId=${stagingId} -Poss-release -Dgpg.keyname='" />
         </exec>
     </target>
     <target name="us-staging" if="sign">


### PR DESCRIPTION
The current version of work with this.argumentIndices caused concurrency issues -- it became executed at the same time as the work with it happened in copyTo(), breaking its value.

The solution was to setup the value as a local variable, set the field as an atomic operation and then use the local variable -- there is no way, how this can be broken.
Of course, it can still happen, that there are multiple values set -- but they are always the same.

The script payaraBuild.sh was fixed and two commands added:
* `prepare` to download all needed libraries
* `upload` to upload the libs to Payara nexus

The Confluence page will be updated accordingly.
