### PR TITLE
FISH-12468 FISH-12986 reapply patches to 5.0.0

### DIFF
--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/boms/bom/pom.xml
+++ b/boms/bom/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/boms/dependencies/pom.xml
+++ b/boms/dependencies/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bom</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../bom/pom.xml</relativePath>
     </parent>
 

--- a/boms/dependencies/pom.xml
+++ b/boms/dependencies/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bom</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../bom/pom.xml</relativePath>
     </parent>
 

--- a/boms/parent/pom.xml
+++ b/boms/parent/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.parent</artifactId>
-    <version>5.0.0.payara-p1</version>
+    <version>5.0.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink Project Parent</name>

--- a/boms/parent/pom.xml
+++ b/boms/parent/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.parent</artifactId>
-    <version>5.0.0.payara-p1-SNAPSHOT</version>
+    <version>5.0.0.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink Project Parent</name>

--- a/boms/tests/pom.xml
+++ b/boms/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.dependencies</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../dependencies/pom.xml</relativePath>
     </parent>
 

--- a/boms/tests/pom.xml
+++ b/boms/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.dependencies</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../dependencies/pom.xml</relativePath>
     </parent>
 

--- a/bundles/eclipse/pom.xml
+++ b/bundles/eclipse/pom.xml
@@ -30,7 +30,7 @@ https://stackoverflow.com/questions/22541301/jarsigner-doesnt-sign-plugin-depend
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.features</artifactId>
-    <version>5.0.0.payara-p1-SNAPSHOT</version>
+    <version>5.0.0.payara-p1</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/bundles/eclipse/pom.xml
+++ b/bundles/eclipse/pom.xml
@@ -30,7 +30,7 @@ https://stackoverflow.com/questions/22541301/jarsigner-doesnt-sign-plugin-depend
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.persistence</groupId>
     <artifactId>org.eclipse.persistence.features</artifactId>
-    <version>5.0.0.payara-p1</version>
+    <version>5.0.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/eclipselink/pom.xml
+++ b/bundles/eclipselink/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/moxy-standalone/pom.xml
+++ b/bundles/moxy-standalone/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/moxy-standalone/pom.xml
+++ b/bundles/moxy-standalone/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/nightly/pom.xml
+++ b/bundles/nightly/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/tests/pom.xml
+++ b/bundles/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundles/tests/pom.xml
+++ b/bundles/tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.bundles</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dbws/eclipselink.dbws.test.oracle/pom.xml
+++ b/dbws/eclipselink.dbws.test.oracle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/dbws/eclipselink.dbws.test.oracle/pom.xml
+++ b/dbws/eclipselink.dbws.test.oracle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/dbws/org.eclipse.persistence.dbws/pom.xml
+++ b/dbws/org.eclipse.persistence.dbws/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/dbws/org.eclipse.persistence.dbws/pom.xml
+++ b/dbws/org.eclipse.persistence.dbws/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.api/pom.xml
+++ b/docs/docs.api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/docs/docs.api/pom.xml
+++ b/docs/docs.api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/docs/docs.concepts/pom.xml
+++ b/docs/docs.concepts/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.concepts/pom.xml
+++ b/docs/docs.concepts/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.dbws/pom.xml
+++ b/docs/docs.dbws/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.dbws/pom.xml
+++ b/docs/docs.dbws/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.jpa/pom.xml
+++ b/docs/docs.jpa/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.jpa/pom.xml
+++ b/docs/docs.jpa/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.moxy/pom.xml
+++ b/docs/docs.moxy/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.moxy/pom.xml
+++ b/docs/docs.moxy/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.solutions/pom.xml
+++ b/docs/docs.solutions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.solutions/pom.xml
+++ b/docs/docs.solutions/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.ug/pom.xml
+++ b/docs/docs.ug/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/docs.ug/pom.xml
+++ b/docs/docs.ug/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.documentation</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/etc/archetypes/bug_test_case/jpa/pom.xml
+++ b/etc/archetypes/bug_test_case/jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <build>

--- a/etc/archetypes/bug_test_case/jpa/pom.xml
+++ b/etc/archetypes/bug_test_case/jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <build>

--- a/etc/archetypes/bug_test_case/moxy/pom.xml
+++ b/etc/archetypes/bug_test_case/moxy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <build>

--- a/etc/archetypes/bug_test_case/moxy/pom.xml
+++ b/etc/archetypes/bug_test_case/moxy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
     <build>

--- a/etc/archetypes/bug_test_case/pom.xml
+++ b/etc/archetypes/bug_test_case/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/etc/archetypes/bug_test_case/pom.xml
+++ b/etc/archetypes/bug_test_case/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/eclipselink.core.test/pom.xml
+++ b/foundation/eclipselink.core.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/eclipselink.core.test/pom.xml
+++ b/foundation/eclipselink.core.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.corba/pom.xml
+++ b/foundation/org.eclipse.persistence.corba/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.corba/pom.xml
+++ b/foundation/org.eclipse.persistence.corba/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core.test.framework/pom.xml
+++ b/foundation/org.eclipse.persistence.core.test.framework/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core.test.framework/pom.xml
+++ b/foundation/org.eclipse.persistence.core.test.framework/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core/pom.xml
+++ b/foundation/org.eclipse.persistence.core/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/config/SystemProperties.java
@@ -206,6 +206,22 @@ public final class SystemProperties {
 
     /**
      * <p>
+     * This property control (enable/disable) if
+     * <code>ConcurrencyException</code> fired when dead-lock diagnostic is
+     * enabled.
+     * <p>
+     * <b>Allowed Values</b> (case sensitive String)<b>:</b>
+     * <ul>
+     * <li>"<code>false</code>" (DEFAULT) - don't collect debug/trace
+     * information during ReadLock acquisition
+     * <li>"<code>true</code>" - collect debug/trace information during ReadLock
+     * acquisition. Has negative impact to the performance.
+     * </ul>
+     */
+    public static final String CONCURRENCY_MANAGER_ALLOW_INTERRUPTION_OF_LOCKWAIT = "eclipselink.concurrency.manager.allow.interruption.lockwait";
+
+    /**
+     * <p>
      * This property control (enable/disable) semaphore in {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder}
      * </p>
      * Object building see {@link org.eclipse.persistence.internal.descriptors.ObjectBuilder} could be one of the

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/FieldExpression.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/expressions/FieldExpression.java
@@ -292,7 +292,11 @@ public class FieldExpression extends DataExpression {
             }
             if ((descriptor != null) && descriptor.hasTablePerClassPolicy()) {
                 field = field.clone();
-                field.setTable(descriptor.getDefaultTable());
+                DatabaseTable table = descriptor.getDefaultTable();
+                if((field.getTableName().length() != 0) && descriptor.getTableNames().contains(field.getTableName())) {
+                    table = descriptor.getTable(field.getTableName());
+                }
+                field.setTable(table);
             }
         }
         FieldExpression expression = new FieldExpression(field, getBaseExpression().rebuildOn(newBase));
@@ -329,7 +333,11 @@ public class FieldExpression extends DataExpression {
             }
             if ((descriptor != null) && descriptor.hasTablePerClassPolicy()) {
                 field = field.clone();
-                field.setTable(descriptor.getDefaultTable());
+                DatabaseTable table = descriptor.getDefaultTable();
+                if((field.getTableName().length() != 0) && descriptor.getTableNames().contains(field.getTableName())) {
+                    table = descriptor.getTable(field.getTableName());
+                }
+                field.setTable(table);
             }
         }
         return twistedBase.getField(field);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyManager.java
@@ -726,7 +726,7 @@ public class ConcurrencyManager implements Serializable {
                         throw ConcurrencyException.waitWasInterrupted(interrupted.getMessage());
                     }
                 }
-            } catch (Error error) {
+            } catch (Error | Exception error) {
                 if (!releaseAllLocksAquiredByThreadAlreadyPerformed) {
                     THREADS_WAITING_TO_RELEASE_DEFERRED_LOCKS.remove(currentThread);
                     AbstractSessionLog.getLog().logThrowable(SessionLog.SEVERE, SessionLog.CACHE, error);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/ConcurrencyUtil.java
@@ -61,6 +61,7 @@ public class ConcurrencyUtil {
     public static final int DEFAULT_CONCURRENCY_MANAGER_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS_NO_THREADS = 2;
     public static final long DEFAULT_CONCURRENCY_SEMAPHORE_MAX_TIME_PERMIT = 2000L;
     public static final long DEFAULT_CONCURRENCY_SEMAPHORE_LOG_TIMEOUT = 10000L;
+    private static final boolean DEFAULT_INTERRUPTION_OF_LOCKWAIT = false;
 
     private long acquireWaitTime = getLongProperty(SystemProperties.CONCURRENCY_MANAGER_ACQUIRE_WAIT_TIME, DEFAULT_ACQUIRE_WAIT_TIME);
     private long buildObjectCompleteWaitTime = getLongProperty(SystemProperties.CONCURRENCY_MANAGER_BUILD_OBJECT_COMPLETE_WAIT_TIME, DEFAULT_BUILD_OBJECT_COMPLETE_WAIT_TIME);
@@ -70,6 +71,7 @@ public class ConcurrencyUtil {
     private boolean allowInterruptedExceptionFired = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTED_EXCEPTION, DEFAULT_INTERRUPTED_EXCEPTION_FIRED);
     private boolean allowConcurrencyExceptionToBeFiredUp = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_CONCURRENCY_EXCEPTION, DEFAULT_CONCURRENCY_EXCEPTION_FIRED);
     private boolean allowTakingStackTraceDuringReadLockAcquisition = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_STACK_TRACE_READ_LOCK, DEFAULT_TAKING_STACKTRACE_DURING_READ_LOCK_ACQUISITION);
+    private boolean allowInterruptionOfLockWait = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_ALLOW_INTERRUPTION_OF_LOCKWAIT, DEFAULT_INTERRUPTION_OF_LOCKWAIT);
 
     private boolean useSemaphoreInObjectBuilder  = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING, DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_OBJECT_BUILDING_CONCURRENCY);
     private boolean useSemaphoreToLimitConcurrencyOnWriteLockManagerAcquireRequiredLocks  = getBooleanProperty(SystemProperties.CONCURRENCY_MANAGER_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS, DEFAULT_USE_SEMAPHORE_TO_SLOW_DOWN_WRITE_LOCK_MANAGER_ACQUIRE_REQUIRED_LOCKS);
@@ -306,6 +308,14 @@ public class ConcurrencyUtil {
 
     public void setAllowTakingStackTraceDuringReadLockAcquisition(boolean allowTakingStackTraceDuringReadLockAcquisition) {
         this.allowTakingStackTraceDuringReadLockAcquisition = allowTakingStackTraceDuringReadLockAcquisition;
+    }
+
+    public boolean isInterruptionOfLockWaitEnabled() {
+        return allowInterruptionOfLockWait;
+    }
+
+    public void setInterruptionOfLockWaitEnabled(boolean interruptionOfLockWaitEnabled) {
+        this.allowInterruptionOfLockWait = interruptionOfLockWaitEnabled;
     }
 
     public boolean isUseSemaphoreInObjectBuilder() {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/helper/WriteLockManager.java
@@ -33,6 +33,7 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.internal.sessions.MergeManager;
 import org.eclipse.persistence.internal.sessions.ObjectChangeSet;
 import org.eclipse.persistence.internal.sessions.UnitOfWorkChangeSet;
+import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.DatabaseMapping;
 
@@ -176,17 +177,21 @@ public class WriteLockManager {
                 // we will now always check for how long the current thread is stuck in this while loop going nowhere
                 // using the exact same approach we have been adding to the concurrency manager
                 ConcurrencyUtil.SINGLETON.determineIfReleaseDeferredLockAppearsToBeDeadLocked(toWaitOn, whileStartTimeMillis, lockManager, readLockManager, ALLOW_INTERRUPTED_EXCEPTION_TO_BE_FIRED_UP_TRUE);
+                SessionLog logger = AbstractSessionLog.getLog();
 
-                toWaitOn.getInstanceLock().lock();
-                try {
-                    if (toWaitOn.isAcquired()) {//last minute check to insure it is still locked.
-                        toWaitOn.getInstanceLockCondition().await(MAX_WAIT, TimeUnit.MILLISECONDS);// wait for lock on object to be released
+                synchronized (toWaitOn) {
+                    try {
+                        if (toWaitOn.isAcquired()) {//last minute check to insure it is still locked.
+                            toWaitOn.wait(ConcurrencyUtil.SINGLETON.getAcquireWaitTime());// wait for lock on object to be released
+                        }
+                    } catch (InterruptedException ex) {
+                        // Allow thread interruptions for bad threads stuck in org.eclipse.persistence.internal.helper.WriteLockManager.acquireLocksForClone
+                        if (ConcurrencyUtil.SINGLETON.isInterruptionOfLockWaitEnabled()) {
+                            logger.log(SessionLog.SEVERE, SessionLog.CACHE, "write_lock_manager_allow_interruption_lockwait_interrupted_throws");
+                            throw ConcurrencyException.waitWasInterrupted(ex.getMessage());
+                        }
+                        logger.log(SessionLog.FINE, SessionLog.CACHE, "write_lock_manager_allow_interruption_lockwait_interrupted_continues");
                     }
-                } catch (InterruptedException ex) {
-                    // Ignore exception thread should continue.
-                }
-                finally {
-                    toWaitOn.getInstanceLock().unlock();
                 }
                 Object waitObject = toWaitOn.getObject();
                 // Object may be null for loss of identity.
@@ -197,6 +202,7 @@ public class WriteLockManager {
                 toWaitOn = acquireLockAndRelatedLocks(objectForClone, lockedObjects, refreshedObjects, cacheKey, descriptor, cloningSession);
                 if ((toWaitOn != null) && ((++tries) > MAXTRIES)) {
                     // If we've tried too many times abort.
+                    logger.log(SessionLog.FINE, SessionLog.CACHE, "write_lock_manager_lockwait_exceeded_max_tries", MAXTRIES);
                     throw ConcurrencyException.maxTriesLockOnCloneExceded(objectForClone);
                 }
             }

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/localization/i18n/TraceLocalizationResource.java
@@ -318,6 +318,9 @@ Total number of cacheKeys to describe: {0}\s
                 + " stopping the candidate thread to make progress... We expect this code spot to never be invoked. "
                 + " Either this thread made progress or if it continues to be stuck in the releaseDeferredLock "
                 + " we most likely have an implementation bug somewhere. "},
+        {"write_lock_manager_lockwait_exceeded_max_tries", "Max {0} tries exceeded during Write Lock Manager acquiring locks for clone."},
+        {"write_lock_manager_allow_interruption_lockwait_interrupted_throws", "Write Lock Manager was interrupted during acquiring locks for clone and 'eclipselink.concurrency.manager.allow.interruption.lockwait' was set to true, throwing ConcurrencyException"},
+        {"write_lock_manager_allow_interruption_lockwait_interrupted_continues", "Write Lock Manager was interrupted during acquiring locks for clone and 'eclipselink.concurrency.manager.allow.interruption.lockwait' was set to false, ignoring and continue"},
         { "concurrency_util_threads_having_difficulty_getting_cache_keys_with_object_different_than_null_during_merge_clones_to_cache_after_transaction_commit_justification",
                 " Merge manager logic is currently stuck in the process of trying to return the cache key: {0}  \n"
                 + " this cache key is currently acquired by a competing thread: {1} . \n"

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/ObjectChangeSet.java
@@ -520,36 +520,47 @@ public class ObjectChangeSet implements Serializable, Comparable<ObjectChangeSet
         CacheKey cacheKey = session.getIdentityMapAccessorInstance().getCacheKeyForObject(primaryKey, descriptor.getJavaClass(), descriptor, true);
         if (cacheKey != null) {
             if (cacheKey.acquireReadLockNoWait()) {
-                domainObject = cacheKey.getObject();
-                cacheKey.releaseReadLock();
+                try {
+                    domainObject = cacheKey.getObject();
+                } catch (Exception exception) {
+                    exception.printStackTrace();
+                }
+                finally {
+                    cacheKey.releaseReadLock();
+                }
             } else {
                 if (!mergeManager.isTransitionedToDeferredLocks()) {
                     session.getIdentityMapAccessorInstance().getWriteLockManager().transitionToDeferredLocks(mergeManager);
                 }
                 cacheKey.acquireDeferredLock();
-                domainObject = cacheKey.getObject();
-                int tries = 0;
-                while (domainObject == null) {
-                    ++tries;
-                    if (tries > MAX_TRIES){
-                        session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
-                        break;
-                    }
-                    cacheKey.getInstanceLock().lock();
-                    try {
-                        if (cacheKey.isAcquired()) {
-                            try {
-                                cacheKey.wait(10);
-                            } catch (InterruptedException e) {
-                                //ignore and return
+                try {
+                    domainObject = cacheKey.getObject();
+                    int tries = 0;
+                    while (domainObject == null) {
+                        ++tries;
+                        if (tries > MAX_TRIES){
+                            if (session.getParent() != null) {
+                                session.getParent().log(SessionLog.SEVERE, SessionLog.CACHE, "entity_not_available_during_merge", new Object[]{descriptor.getJavaClassName(), cacheKey.getKey(), Thread.currentThread().getName(), cacheKey.getActiveThread()});
                             }
+                            break;
                         }
-                        domainObject = cacheKey.getObject();
-                    } finally {
-                        cacheKey.getInstanceLock().unlock();
+                        synchronized (cacheKey) {
+                            if (cacheKey.isAcquired()) {
+                                try {
+                                    cacheKey.wait(10);
+                                } catch (InterruptedException e) {
+                                    //ignore and return
+                                }
+                            }
+                            domainObject = cacheKey.getObject();
+                        }
                     }
+                } catch (Exception exception) {
+                    exception.printStackTrace();
                 }
-                cacheKey.releaseDeferredLock();
+                finally {
+                    cacheKey.releaseDeferredLock();
+                }
             }
         } else {
             domainObject = mergeManager.registerExistingObjectOfReadOnlyClassInNestedTransaction(getUnitOfWorkClone(), descriptor, session);

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/internal/sessions/UnitOfWorkImpl.java
@@ -3051,7 +3051,7 @@ public class UnitOfWorkImpl extends AbstractSession implements org.eclipse.persi
             return null;
         }
         if (descriptor.isDescriptorTypeAggregate()) {
-            throw ValidationException.cannotRegisterAggregateObjectInUnitOfWork(object.getClass());
+           return null;
         }
         Object registeredObject = checkIfAlreadyRegistered(object, descriptor);
         if (registeredObject == null) {

--- a/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/H2Platform.java
+++ b/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/H2Platform.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class H2Platform extends DatabasePlatform {
     @Serial
@@ -108,6 +109,8 @@ public class H2Platform extends DatabasePlatform {
         fieldTypeMapping.put(char[].class, new FieldDefinition.DatabaseType("LONGVARCHAR", false));
         fieldTypeMapping.put(java.sql.Blob.class, new FieldDefinition.DatabaseType("BLOB", false));
         fieldTypeMapping.put(java.sql.Clob.class, new FieldDefinition.DatabaseType("CLOB", false));
+
+        fieldTypeMapping.put(UUID.class, new FieldDefinition.DatabaseType("BINARY", 16));
 
         fieldTypeMapping.put(java.sql.Date.class, new FieldDefinition.DatabaseType("DATE", false));
         fieldTypeMapping.put(java.sql.Timestamp.class, new FieldDefinition.DatabaseType("TIMESTAMP", false));

--- a/foundation/org.eclipse.persistence.extension/pom.xml
+++ b/foundation/org.eclipse.persistence.extension/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.extension/pom.xml
+++ b/foundation/org.eclipse.persistence.extension/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.json/pom.xml
+++ b/foundation/org.eclipse.persistence.json/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.json/pom.xml
+++ b/foundation/org.eclipse.persistence.json/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.nosql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.nosql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.nosql/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle.test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oracle/pom.xml
+++ b/foundation/org.eclipse.persistence.oracle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oxm.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oxm.test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.oxm.test/pom.xml
+++ b/foundation/org.eclipse.persistence.oxm.test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.pgsql/pom.xml
+++ b/foundation/org.eclipse.persistence.pgsql/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/foundation/org.eclipse.persistence.pgsql/pom.xml
+++ b/foundation/org.eclipse.persistence.pgsql/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jaxrs.test/pom.xml
+++ b/jpa/eclipselink.jaxrs.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jaxrs.test/pom.xml
+++ b/jpa/eclipselink.jaxrs.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.spring.test/pom.xml
+++ b/jpa/eclipselink.jpa.spring.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.spring.test/pom.xml
+++ b/jpa/eclipselink.jpa.spring.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.test.jse/pom.xml
+++ b/jpa/eclipselink.jpa.test.jse/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.test.jse/pom.xml
+++ b/jpa/eclipselink.jpa.test.jse/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.test/pom.xml
+++ b/jpa/eclipselink.jpa.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.test/pom.xml
+++ b/jpa/eclipselink.jpa.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.nosql</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/jpa.test.nosql.mongo/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.nosql</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.nosql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../eclipselink.jpa.testapps/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.nosql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.nosql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../eclipselink.jpa.testapps/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.customfeatures/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.dcn/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.partitioned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.partitioned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.partitioned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.partitioned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.plsql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.proxyauthentication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.spatial/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.spatial/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/jpa.test.oracle.timestamptz/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../eclipselink.jpa.testapps/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.oracle/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../eclipselink.jpa.testapps/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps.oracle/test.oracle.spatial/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/test.oracle.spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps.oracle/test.oracle.spatial/pom.xml
+++ b/jpa/eclipselink.jpa.testapps.oracle/test.oracle.spatial/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps.oracle</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.additionalcriteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.additionalcriteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.additionalcriteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.additionalcriteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cacheimpl/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cacheimpl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cacheimpl/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cacheimpl/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cascadepersist/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cascadepersist/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cascadepersist/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.cascadepersist/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.compositepk/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.compositepk/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.compositepk/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.compositepk/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.customer/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.customer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.customer/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.customer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.derivedid/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.derivedid/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.derivedid/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.derivedid/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.embeddable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.embeddable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.embeddable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.embeddable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.fetchgroup/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.fetchgroup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.fetchgroup/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.fetchgroup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced.multitenant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.advanced2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.batchfetch/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.batchfetch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.batchfetch/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.batchfetch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation.dynamic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation.dynamic/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation.dynamic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation.dynamic/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.beanvalidation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.cacheable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.cacheable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.cacheable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.cacheable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.cascadedeletes/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.cascadedeletes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.cascadedeletes/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.cascadedeletes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.complexaggregate/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.complexaggregate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.complexaggregate/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.complexaggregate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/common/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/common/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.criteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.criteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.criteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.criteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datatypes/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.datetime/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.datetime/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.ddlgeneration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.delimited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.delimited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.delimited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.delimited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic.deadlock/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.diagnostic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.extensibility/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.extensibility/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.extensibility/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.extensibility/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fetchgroups/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fetchgroups/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fetchgroups/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fetchgroups/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.fieldaccess.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.identity/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.identity/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.identity/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.identity/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpaadvancedproperties/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jpql/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jpql/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jta/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jta/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.jta/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.jta/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.lob/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.lob/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.lob/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.lob/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.memory/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.memory/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.memory/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.memory/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel.apectj/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.metamodel/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.orphanremoval/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.orphanremoval/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.orphanremoval/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.orphanremoval/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.partitioned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.partitioned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.partitioned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.partitioned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.performance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.performance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.performance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.performance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.performance2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.performance2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.performance2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.performance2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32.nofile/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.persistence32/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.privateowned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.privateowned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.privateowned/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.privateowned/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.pu with spaces/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.pu with spaces/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.pu with spaces/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.pu with spaces/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.remote/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.remote/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.remote/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.remote/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean.ha/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.sessionbean/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.validation/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.validation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.validation/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.validation/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.weaving/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/common/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/common/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_1/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_1/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_2/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_2/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_3/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/member_3/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended.composite.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.additionalcriteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.additionalcriteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.additionalcriteria/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.additionalcriteria/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.dynamic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.dynamic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.dynamic/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.dynamic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.fetchgroup/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.fetchgroup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.fetchgroup/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced.fetchgroup/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.complexaggregate/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.complexaggregate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.complexaggregate/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.complexaggregate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.extended/jpa.test.xml.extended.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.nonowning/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.nonowning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.nonowning/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.nonowning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.owning/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.owning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.owning/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.incompletemappings.owning/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.merge/jpa.test.xml.merge.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced.multitenant/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced.multitenant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced.multitenant/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced.multitenant/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.advanced/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.cacheable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.cacheable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.cacheable/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.cacheable/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inheritance/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inheritance/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.inherited/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.metadatacomplete/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.metadatacomplete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.metadatacomplete/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.metadatacomplete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships.unidirectional/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships.unidirectional/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships.unidirectional/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships.unidirectional/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.only/jpa.test.xml.relationships/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.xmlmetadatacomplete/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.xmlmetadatacomplete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/jpa.test.xml.xmlmetadatacomplete/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/jpa.test.xml.xmlmetadatacomplete/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/nativeapi/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/nativeapi/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/nativeapi/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/nativeapi/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.jpa.testapps</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.project</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.testapps/pom.xml
+++ b/jpa/eclipselink.jpa.testapps/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.project</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.wdf.test/pom.xml
+++ b/jpa/eclipselink.jpa.wdf.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpa.wdf.test/pom.xml
+++ b/jpa/eclipselink.jpa.wdf.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpars.test/pom.xml
+++ b/jpa/eclipselink.jpars.test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/eclipselink.jpars.test/pom.xml
+++ b/jpa/eclipselink.jpars.test/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.jpql/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.modelgen/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa.test.framework/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa/pom.xml
+++ b/jpa/org.eclipse.persistence.jpa/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/ManagedTypeImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/ManagedTypeImpl.java
@@ -87,6 +87,7 @@ import org.eclipse.persistence.internal.queries.ContainerPolicy;
 import org.eclipse.persistence.internal.security.PrivilegedAccessHelper;
 import org.eclipse.persistence.internal.security.PrivilegedGetDeclaredField;
 import org.eclipse.persistence.internal.security.PrivilegedGetDeclaredMethod;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.logging.AbstractSessionLog;
 import org.eclipse.persistence.logging.SessionLog;
 import org.eclipse.persistence.mappings.CollectionMapping;
@@ -1326,6 +1327,18 @@ public abstract class ManagedTypeImpl<X> extends TypeImpl<X> implements ManagedT
             }
 
             this.members.put(mapping.getAttributeName(), member);
+        }
+    }
+    
+    public void preinitaliseMappings(AbstractSession session) {
+        for (DatabaseMapping mapping : getDescriptor().getMappings()) {
+            try {
+                mapping.preInitialize(session);
+            } catch (NullPointerException npe) {
+                // A NPE gets thrown if the expected method is not present for the mapping
+                AbstractSessionLog.getLog().log(SessionLog.FINE, "Caught NPE when preinitializing database mapping",
+                        npe.getMessage());
+            }
         }
     }
 

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
@@ -497,8 +497,12 @@ public class MetamodelImpl implements Metamodel, Serializable {
             }
         }
 
-        //1 - process all non-mappedSuperclass types first, so we pick up attribute types
-        //2 - process mappedSuperclass types and lookup collection attribute types on inheriting entity types when field is not set
+        //1 - preinitalise all mappings so attribute types are set
+        //2 - process all non-mappedSuperclass types first, so we pick up attribute types
+        //3 - process mappedSuperclass types and lookup collection attribute types on inheriting entity types when field is not set
+        for(ManagedTypeImpl<?> managedType : new ArrayList<ManagedTypeImpl<?>>(managedTypes.values())) {
+            managedType.preinitaliseMappings(session);
+        }
 
         /*
          * Delayed-Initialization (process all mappings) of all Managed types
@@ -525,7 +529,7 @@ public class MetamodelImpl implements Metamodel, Serializable {
         }
         isInitialized = true;
     }
-
+    
     /**
      *  Return the metamodel managed type representing the
      *  entity, mapped superclass, or embeddable class.

--- a/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
+++ b/jpa/org.eclipse.persistence.jpa/src/main/java/org/eclipse/persistence/internal/jpa/metamodel/MetamodelImpl.java
@@ -514,7 +514,7 @@ public class MetamodelImpl implements Metamodel, Serializable {
             managedType.initialize();
         }
 
-        // 3 - process all the Id attributes on each IdentifiableType
+        // 4 - process all the Id attributes on each IdentifiableType
         for(ManagedTypeImpl<?> potentialIdentifiableType : managedTypes.values()) {
             if(potentialIdentifiableType.isIdentifiableType()) {
                 ((IdentifiableTypeImpl<?>)potentialIdentifiableType).initializeIdAttributes();

--- a/jpa/org.eclipse.persistence.jpars.server/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpars.server/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jpa/org.eclipse.persistence.jpars/pom.xml
+++ b/jpa/org.eclipse.persistence.jpars/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy.utils.xjc/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy/pom.xml
+++ b/moxy/org.eclipse.persistence.moxy/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/ValidationXMLReader.java
+++ b/moxy/org.eclipse.persistence.moxy/src/main/java/org/eclipse/persistence/jaxb/ValidationXMLReader.java
@@ -93,7 +93,8 @@ public class ValidationXMLReader implements Callable<Map<Class<?>, Boolean>> {
      * Checks if validation.xml exists.
      */
     public static boolean isValidationXmlPresent() {
-        return getThreadContextClassLoader().getResource(VALIDATION_XML) != null;
+        ClassLoader threadContextClassLoader = getThreadContextClassLoader();
+        return threadContextClassLoader != null && threadContextClassLoader.getResource(VALIDATION_XML) != null;
     }
 
     private void parseConstraintFiles() {
@@ -169,7 +170,14 @@ public class ValidationXMLReader implements Callable<Map<Class<?>, Boolean>> {
 
     private static ClassLoader getThreadContextClassLoader() {
         return PrivilegedAccessHelper.callDoPrivileged(
-                () -> Thread.currentThread().getContextClassLoader()
+                () ->  {
+                    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+                    if (classLoader == null) {
+                        Thread.currentThread().setContextClassLoader(ClassLoader.getSystemClassLoader());
+                        classLoader = Thread.currentThread().getContextClassLoader();
+                    }
+                    return classLoader;
+                }
         );
     }
 

--- a/performance/eclipselink.perf.test/pom.xml
+++ b/performance/eclipselink.perf.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.project</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/performance/eclipselink.perf.test/pom.xml
+++ b/performance/eclipselink.perf.test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.project</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.tests.bom</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>boms/tests/pom.xml</relativePath>
     </parent>
 
     <artifactId>org.eclipse.persistence.project</artifactId>
-    <version>5.0.0.payara-p1</version>
+    <version>5.0.0.payara-p2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.tests.bom</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>boms/tests/pom.xml</relativePath>
     </parent>
 
     <artifactId>org.eclipse.persistence.project</artifactId>
-    <version>5.0.0.payara-p1-SNAPSHOT</version>
+    <version>5.0.0.payara-p1</version>
     <packaging>pom</packaging>
 
     <name>EclipseLink Project</name>

--- a/sdo/eclipselink.sdo.test.server/pom.xml
+++ b/sdo/eclipselink.sdo.test.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/sdo/eclipselink.sdo.test.server/pom.xml
+++ b/sdo/eclipselink.sdo.test.server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../testing/server/pom.xml</relativePath>
     </parent>
 

--- a/sdo/org.eclipse.persistence.sdo/pom.xml
+++ b/sdo/org.eclipse.persistence.sdo/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/sdo/org.eclipse.persistence.sdo/pom.xml
+++ b/sdo/org.eclipse.persistence.sdo/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/server-oracle/pom.xml
+++ b/testing/server-oracle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/server-oracle/pom.xml
+++ b/testing/server-oracle/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/server/pom.xml
+++ b/testing/server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.project</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/server/pom.xml
+++ b/testing/server/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>org.eclipse.persistence.project</artifactId>
         <groupId>org.eclipse.persistence</groupId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.oracle.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../testing/server-oracle/pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle.server/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.oracle.test.server.parent</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../testing/server-oracle/pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.dbws.builder.test.oracle/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.dbws.builder.test.oracle/pom.xml
+++ b/utils/eclipselink.dbws.builder.test.oracle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.utils.rename/pom.xml
+++ b/utils/eclipselink.utils.rename/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.utils.rename/pom.xml
+++ b/utils/eclipselink.utils.rename/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.utils.sigcompare/pom.xml
+++ b/utils/eclipselink.utils.sigcompare/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/eclipselink.utils.sigcompare/pom.xml
+++ b/utils/eclipselink.utils.sigcompare/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/org.eclipse.persistence.dbws.builder/pom.xml
+++ b/utils/org.eclipse.persistence.dbws.builder/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1</version>
+        <version>5.0.0.payara-p2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/utils/org.eclipse.persistence.dbws.builder/pom.xml
+++ b/utils/org.eclipse.persistence.dbws.builder/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.persistence</groupId>
         <artifactId>org.eclipse.persistence.project</artifactId>
-        <version>5.0.0.payara-p1-SNAPSHOT</version>
+        <version>5.0.0.payara-p1</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Reapplies applicable EclipseLink patches

Also now includes an additional fix for FISH-12468 https://github.com/payara/patched-src-eclipselink/pull/50

Passed unit tests, TCK run of standalone persistence and Data passed